### PR TITLE
Prevent stringToColor from throwing an error when parsing partial hex code

### DIFF
--- a/projects/iplab/ngx-color-picker/src/lib/helpers/color.class.ts
+++ b/projects/iplab/ngx-color-picker/src/lib/helpers/color.class.ts
@@ -464,7 +464,7 @@ export class Color {
             let hex = str.substr(1);
             const length = hex.length;
             let a = 1;
-            let hexArray;
+            let hexArray = [];
 
             if (length === 3) {
                 hexArray = hex.split('').map((value) => value + value);


### PR DESCRIPTION
line 480 (`hexArray.length`) throws an error if this method parses a partial hex code, as `hexArray` will be undefined.