### PR TITLE
Fix for isVertical type definitions to support consumer project with strictTemplates

### DIFF
--- a/projects/iplab/ngx-color-picker/src/lib/components/parts/alpha/alpha.component.ts
+++ b/projects/iplab/ngx-color-picker/src/lib/components/parts/alpha/alpha.component.ts
@@ -30,7 +30,7 @@ export class AlphaComponent extends BaseComponent {
 
     public colorChange: OutputEmitterRef<Color> = output<Color>();
 
-    public isVertical: InputSignal<boolean> = input<boolean, boolean>(false, { alias: 'vertical', transform: booleanAttribute });
+    public isVertical: InputSignal<boolean | string> = input<boolean | string, boolean>(false, { alias: 'vertical', transform: booleanAttribute });
 
     @ViewChild('pointer', { static: true })
     public pointer: ElementRef;

--- a/projects/iplab/ngx-color-picker/src/lib/components/parts/hue/hue.component.ts
+++ b/projects/iplab/ngx-color-picker/src/lib/components/parts/hue/hue.component.ts
@@ -29,7 +29,7 @@ export class HueComponent extends BaseComponent {
 
     public color: ModelSignal<Color> = model.required<Color>();
 
-    public isVertical: InputSignal<boolean> = input<boolean, boolean>(false, { alias: 'vertical', transform: booleanAttribute });
+    public isVertical: InputSignal<boolean | string> = input<boolean | string, boolean>(false, { alias: 'vertical', transform: booleanAttribute });
 
     public readonly pointer: Signal<ElementRef> = viewChild.required<ElementRef>('pointer');
 


### PR DESCRIPTION
This change set allows to use `<hue-component vertical [(color)]="color"/>` in projects which are configured to use strict templates.
See details in #95.